### PR TITLE
Remove RNPM to make it build with RN 0.61

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,11 +26,5 @@
   "peerDependencies": {
     "react-native": ">=0.40"
   },
-  "dependencies": {},
-  "rnpm": {
-    "android": {
-      "packageInstance": "new HotspotModule()"
-    }
-  }
-
+  "dependencies": {}
 }


### PR DESCRIPTION
WRT this:
https://github.com/assemmohamedali/react-native-wifi-hotspot/issues/14

This removes the "react-native link ..." requirement and makes it compile on RN 0.61